### PR TITLE
feat: add configurable screensaver with optional no-CO2 layout

### DIFF
--- a/src/common/fonts.yaml
+++ b/src/common/fonts.yaml
@@ -91,6 +91,14 @@
       glyphs: "אבגדהוזחטיכךלמםנןסעפףצץקרשת׳״"
 
 - file: "assets/fonts/Nunito-SemiBold.ttf"
+  id: nunito_72
+  size: 72
+  bpp: 4
+  glyphsets:
+    - GF_Latin_Core
+    - GF_Cyrillic_Core
+
+- file: "assets/fonts/Nunito-SemiBold.ttf"
   id: nunito_84
   size: 84
   bpp: 4

--- a/src/common/substitutions.yaml
+++ b/src/common/substitutions.yaml
@@ -5,9 +5,10 @@ display_friendly_name:    Display My Room
 
 # ENTITIES
 
-weather_entity:           "weather.home_assistant"
-temperature_entity:       "sensor.outside_temperature"
-humidity_entity:          "sensor.outside_humidity"
+weather_entity:           "weather.yandex_pogoda"
+temperature_entity:       "sensor.climate_lounge_room_temperature"
+humidity_entity:          "sensor.climate_lounge_room_humidity"
+co2_entity:               "sensor.co2_lounge_room_co2"
 
 
 

--- a/src/common/substitutions.yaml
+++ b/src/common/substitutions.yaml
@@ -6,6 +6,7 @@ display_friendly_name:    Display My Room
 # ENTITIES
 
 weather_entity:           "weather.home_assistant"
+feels_like_temperature_entity: "sensor.feels_like_temperature"
 temperature_entity:       "sensor.outside_temperature"
 humidity_entity:          "sensor.outside_humidity"
 co2_entity:               "sensor.carbon_dioxide"

--- a/src/common/substitutions.yaml
+++ b/src/common/substitutions.yaml
@@ -5,10 +5,11 @@ display_friendly_name:    Display My Room
 
 # ENTITIES
 
-weather_entity:           "weather.yandex_pogoda"
-temperature_entity:       "sensor.climate_lounge_room_temperature"
-humidity_entity:          "sensor.climate_lounge_room_humidity"
-co2_entity:               "sensor.co2_lounge_room_co2"
+weather_entity:           "weather.home_assistant"
+temperature_entity:       "sensor.outside_temperature"
+humidity_entity:          "sensor.outside_humidity"
+co2_entity:               "sensor.carbon_dioxide"
+has_co2:                  "true"
 
 
 

--- a/src/main.yaml
+++ b/src/main.yaml
@@ -10,6 +10,7 @@ packages:
   # boiler: !include widgets/boiler/config.yaml
   # alarm_panel: !include widgets/alarm_panel/config.yaml
   fan: !include widgets/fan/config.yaml
+  screensaver: !include widgets/screensaver.yaml
 
 
 substitutions: !include common/substitutions.yaml
@@ -67,9 +68,23 @@ esphome:
         - script.execute: update_loading_page
     - priority: -100
       then:
+        - number.set:
+            id: display_timeout_backlight
+            value: !lambda |-
+              int idx = id(display_timeout);
+              if (idx < 0 || idx > 6) {
+                idx = 3;
+                id(display_timeout) = idx;
+              }
+              static const int screensaver_time[] = {-1, 15, 30, 60, 120, 300, 600};
+              return screensaver_time[idx];
         - lvgl.roller.update:
             id: backlight_settings_sleep_time_roller
-            selected_index: !lambda return id(display_timeout);
+            selected_index: !lambda |-
+              if (id(display_timeout) < 0 || id(display_timeout) > 6) {
+                return 3;
+              }
+              return id(display_timeout);
 
 esp32:
   board: esp32-s3-devkitc-1
@@ -263,12 +278,8 @@ light:
             - lvgl.resume:
             - lvgl.widget.redraw:
     on_turn_off:
-      - if:
-          condition:
-            lambda: 'return id(display_timeout_backlight).state >= 0;'
-          then:
-            - logger.log: "Backlight off, pausing LVGL"
-            - lvgl.pause:
+      - logger.log: "Backlight off, pausing LVGL"
+      - lvgl.pause:
 
 output:
     # Backlight LED
@@ -295,12 +306,22 @@ touchscreen:
   display: ${display_name}
   on_release:
       - if:
+          condition:
+            lambda: 'return id(screensaver_active);'
+          then:
+            - script.execute: hide_screensaver
+      - if:
+          condition:
+            light.is_off: display_backlight
+          then:
+            - logger.log: "Touch wake, backlight on"
+            - light.turn_on: display_backlight
+      - if:
           condition: lvgl.is_paused
           then:
             - logger.log: "LVGL resuming"
             - lvgl.resume:
             - lvgl.widget.redraw:
-            - light.turn_on: display_backlight
 
   # on_touch:
   #   - lambda: |-

--- a/src/main.yaml
+++ b/src/main.yaml
@@ -68,23 +68,41 @@ esphome:
         - script.execute: update_loading_page
     - priority: -100
       then:
+        - script.execute: configure_screensaver_layout
         - number.set:
             id: display_timeout_backlight
             value: !lambda |-
               int idx = id(display_timeout);
-              if (idx < 0 || idx > 6) {
-                idx = 3;
+              if (idx < 0 || idx > 7) {
+                idx = 2;
                 id(display_timeout) = idx;
+              }
+              static const int backlight_time[] = {-1, 1, 5, 10, 30, 60, 360, 720};
+              return backlight_time[idx];
+        - lvgl.roller.update:
+            id: backlight_settings_sleep_time_roller
+            selected_index: !lambda |-
+              if (id(display_timeout) < 0 || id(display_timeout) > 7) {
+                return 2;
+              }
+              return id(display_timeout);
+        - number.set:
+            id: screensaver_timeout_number
+            value: !lambda |-
+              int idx = id(screensaver_timeout);
+              if (idx < 0 || idx > 6) {
+                idx = 2;
+                id(screensaver_timeout) = idx;
               }
               static const int screensaver_time[] = {-1, 15, 30, 60, 120, 300, 600};
               return screensaver_time[idx];
         - lvgl.roller.update:
-            id: backlight_settings_sleep_time_roller
+            id: screensaver_timeout_roller
             selected_index: !lambda |-
-              if (id(display_timeout) < 0 || id(display_timeout) > 6) {
-                return 3;
+              if (id(screensaver_timeout) < 0 || id(screensaver_timeout) > 6) {
+                return 2;
               }
-              return id(display_timeout);
+              return id(screensaver_timeout);
 
 esp32:
   board: esp32-s3-devkitc-1

--- a/src/widgets/home/home.yaml
+++ b/src/widgets/home/home.yaml
@@ -191,6 +191,52 @@ sensor:
             text:
               format: "%.0f°"
               args: [id(weather_temperature_sensor).state]
+        - if:
+            condition:
+              lambda: |-
+                if (!id(weather_feels_like_temperature_sensor).has_state()) return false;
+                float feels_like = id(weather_feels_like_temperature_sensor).state;
+                return !isnan(feels_like) && abs((int) roundf(feels_like) - (int) roundf(x)) >= 2;
+            then:
+              - lambda: |-
+                  lv_obj_set_y(id(screensaver_outdoor_temp_value), -42);
+              - lvgl.label.update:
+                  id: screensaver_outdoor_feels_like_value
+                  text:
+                    format: "~%.0f°"
+                    args: [id(weather_feels_like_temperature_sensor).state]
+              - lvgl.widget.show: screensaver_outdoor_feels_like_value
+            else:
+              - lvgl.widget.hide: screensaver_outdoor_feels_like_value
+              - lambda: |-
+                  lv_obj_set_y(id(screensaver_outdoor_temp_value), -3);
+
+  # Weather feels-like temperature sensor
+  - platform: homeassistant
+    id: weather_feels_like_temperature_sensor
+    entity_id: "${feels_like_temperature_entity}"
+    on_value:
+      then:
+        - if:
+            condition:
+              lambda: |-
+                if (isnan(x)) return false;
+                if (!id(weather_temperature_sensor).has_state()) return true;
+                float outdoor = id(weather_temperature_sensor).state;
+                return isnan(outdoor) || abs((int) roundf(x) - (int) roundf(outdoor)) >= 2;
+            then:
+              - lambda: |-
+                  lv_obj_set_y(id(screensaver_outdoor_temp_value), -42);
+              - lvgl.label.update:
+                  id: screensaver_outdoor_feels_like_value
+                  text:
+                    format: "~%.0f°"
+                    args: [x]
+              - lvgl.widget.show: screensaver_outdoor_feels_like_value
+            else:
+              - lvgl.widget.hide: screensaver_outdoor_feels_like_value
+              - lambda: |-
+                  lv_obj_set_y(id(screensaver_outdoor_temp_value), -3);
 
   # Weather humidity sensor
   - platform: homeassistant

--- a/src/widgets/home/home.yaml
+++ b/src/widgets/home/home.yaml
@@ -13,6 +13,11 @@ globals:
     restore_value: yes
     initial_value: '2'
 
+  - id: screensaver_timeout
+    type: int
+    restore_value: yes
+    initial_value: '2'
+
   # Данные daily прогноза
   - id: forecast_daily_count
     type: int
@@ -60,10 +65,22 @@ globals:
 number:
   - platform: template
     id: display_timeout_backlight
+    name: Backlight timeout
+    optimistic: true
+    unit_of_measurement: "m"
+    initial_value: 10
+    restore_value: true
+    min_value: -1
+    max_value: 720
+    step: 1
+    mode: box
+
+  - platform: template
+    id: screensaver_timeout_number
     name: Screensaver timeout
     optimistic: true
     unit_of_measurement: "s"
-    initial_value: 60
+    initial_value: 30
     restore_value: true
     min_value: -1
     max_value: 600
@@ -129,6 +146,18 @@ time:
         seconds: 0
         then:
           - script.execute: time_update
+
+interval:
+  - interval: 1s
+    then:
+      - if:
+          condition:
+            lambda: |-
+              if (id(screensaver_timeout_number).state < 0 || id(screensaver_active)) return false;
+              if (!id(display_backlight).current_values.is_on()) return false;
+              return lv_disp_get_inactive_time(NULL) >= (id(screensaver_timeout_number).state * 1000);
+          then:
+            - script.execute: show_screensaver
 
 
 sensor:
@@ -215,12 +244,20 @@ sensor:
             text:
               format: "%.1f°"
               args: [id(home_temperature_sensor).state]
+        - lvgl.label.update:
+            id: screensaver_temp_no_co2_value
+            text:
+              format: "%.1f°"
+              args: [id(home_temperature_sensor).state]
         - if:
             condition:
               lambda: 'return id(home_temperature_sensor).state >= 30.0;'
             then:
               - lvgl.label.update:
                   id: screensaver_indoor_temp_value
+                  text_color: color_red
+              - lvgl.label.update:
+                  id: screensaver_temp_no_co2_value
                   text_color: color_red
             else:
               - if:
@@ -230,9 +267,15 @@ sensor:
                     - lvgl.label.update:
                         id: screensaver_indoor_temp_value
                         text_color: color_orange
+                    - lvgl.label.update:
+                        id: screensaver_temp_no_co2_value
+                        text_color: color_orange
                   else:
                     - lvgl.label.update:
                         id: screensaver_indoor_temp_value
+                        text_color: color_misty_blue
+                    - lvgl.label.update:
+                        id: screensaver_temp_no_co2_value
                         text_color: color_misty_blue
 
   # Home humidity sensor
@@ -451,18 +494,17 @@ text_sensor:
 lvgl:
 
   on_idle:
-    timeout: !lambda |-
-      if (id(display_timeout_backlight).state < 0) {
-        return 2147483647;
-      }
-      return (uint32_t) (id(display_timeout_backlight).state * 1000);
+    timeout: !lambda "return (id(display_timeout_backlight).state * 60 * 1000);"
     then:
       - if:
           condition:
             lambda: 'return id(display_timeout_backlight).state >= 0;'
           then:
             - logger.log: "LVGL is idle"
-            - script.execute: show_screensaver
+            - light.turn_off: display_backlight
+            - lvgl.pause:
+          else:
+            - logger.log: "LVGL idle, but backlight is on"
 
   pages:
     - id: home_page
@@ -886,16 +928,16 @@ lvgl:
                         border_width: 0
                         shadow_opa: transp
                         widgets:
-                          - label:  
+                          - label:
                               id: backlight_settings_sleep_time_label
-                              y: 20
+                              y: 23
                               align: top_mid
                               text_font: nunito_18
                               text_color: color_misty_blue
                               text: "Sleep time"
                           - roller:
                               id: backlight_settings_sleep_time_roller
-                              y: 10
+                              y: -33
                               width: 140
                               align: center
                               bg_opa: transp
@@ -909,10 +951,59 @@ lvgl:
                                 text_font: nunito_20
                                 text_color: color_misty_blue
                               selected_index: !lambda |-
-                                if (id(display_timeout) < 0 || id(display_timeout) > 6) {
-                                  return 3;
+                                if (id(display_timeout) < 0 || id(display_timeout) > 7) {
+                                  return 2;
                                 }
                                 return id(display_timeout);
+                              options:
+                                - Never
+                                - 1 minute
+                                - 5 minutes
+                                - 10 minutes
+                                - 30 minutes
+                                - 1 hour
+                                - 6 hours
+                                - 12 hours
+                              visible_row_count: 1
+                              on_value:
+                                  then:
+                                    - number.set:
+                                        id: display_timeout_backlight
+                                        value: !lambda |-
+                                          static const int backlight_time[] = {-1, 1, 5, 10, 30, 60, 360, 720};
+                                          return backlight_time[x];
+                                    - globals.set:
+                                        id: display_timeout
+                                        value: !lambda return x;
+
+                          - label:
+                              id: screensaver_timeout_label
+                              y: 131
+                              align: top_mid
+                              text_font: nunito_18
+                              text_color: color_misty_blue
+                              text: "Screensaver"
+
+                          - roller:
+                              id: screensaver_timeout_roller
+                              y: 75
+                              width: 140
+                              align: center
+                              bg_opa: transp
+                              border_opa: transp
+                              shadow_opa: transp
+                              text_font: nunito_20
+                              text_color: color_steel_blue
+                              text_line_space: 4
+                              selected:
+                                bg_opa: transp
+                                text_font: nunito_20
+                                text_color: color_misty_blue
+                              selected_index: !lambda |-
+                                if (id(screensaver_timeout) < 0 || id(screensaver_timeout) > 6) {
+                                  return 2;
+                                }
+                                return id(screensaver_timeout);
                               options:
                                 - Never
                                 - 15 seconds
@@ -925,13 +1016,18 @@ lvgl:
                               on_value:
                                   then:
                                     - number.set:
-                                        id: display_timeout_backlight
+                                        id: screensaver_timeout_number
                                         value: !lambda |-
-                                          static const int backlight_time[] = {-1, 15, 30, 60, 120, 300, 600};
-                                          return backlight_time[x];
+                                          static const int screensaver_time[] = {-1, 15, 30, 60, 120, 300, 600};
+                                          return screensaver_time[x];
                                     - globals.set:
-                                        id: display_timeout
+                                        id: screensaver_timeout
                                         value: !lambda return x;
+                                    - if:
+                                        condition:
+                                          lambda: 'return x == 0;'
+                                        then:
+                                          - script.execute: hide_screensaver
 
 
         - obj:
@@ -1757,17 +1853,22 @@ script:
 
           uint16_t old_selection = lv_roller_get_selected(roller_obj);
 
-          std::string options =
-            "Never\n"
-            "15 seconds\n"
-            "30 seconds\n"
-            "1 minute\n"
-            "2 minutes\n"
-            "5 minutes\n"
-            "10 minutes";
+          std::string options = 
+            id(i18n_translations).translate("sleep_time.never") + "\n" +
+            id(i18n_translations).translate("sleep_time.minute1") + "\n" +
+            id(i18n_translations).translate("sleep_time.minute5") + "\n" +
+            id(i18n_translations).translate("sleep_time.minute10") + "\n" +
+            id(i18n_translations).translate("sleep_time.minute30") + "\n" +
+            id(i18n_translations).translate("sleep_time.hour1") + "\n" +
+            id(i18n_translations).translate("sleep_time.hour6") + "\n" +
+            id(i18n_translations).translate("sleep_time.hour12");
 
           lv_roller_set_options(roller_obj, options.c_str(), LV_ROLLER_MODE_NORMAL);
           lv_roller_set_selected(roller_obj, old_selection, LV_ANIM_OFF);
+
+      - lvgl.label.update:
+          id: screensaver_timeout_label
+          text: "Screensaver"
 
 
   - id: display_block_buttons
@@ -1791,6 +1892,7 @@ script:
             - lvgl.button.update: { id: weather_forecast_hourly_btn, clickable: true }
             - lvgl.slider.update: { id: backlight_settings_brightness_slider, clickable: true }
             - lvgl.roller.update: { id: backlight_settings_sleep_time_roller, clickable: true }
+            - lvgl.roller.update: { id: screensaver_timeout_roller, clickable: true }
             - lvgl.button.update: { id: circle_settings_widget_lang_btn, clickable: true }
           else:
             - lvgl.label.update:
@@ -1807,6 +1909,7 @@ script:
             - lvgl.button.update: { id: weather_forecast_hourly_btn, clickable: false }
             - lvgl.slider.update: { id: backlight_settings_brightness_slider, clickable: false }
             - lvgl.roller.update: { id: backlight_settings_sleep_time_roller, clickable: false }
+            - lvgl.roller.update: { id: screensaver_timeout_roller, clickable: false }
             - lvgl.button.update: { id: circle_settings_widget_lang_btn, clickable: false }
 
   - id: update_weather_image
@@ -1928,6 +2031,14 @@ script:
 
       - lvgl.label.update:
           id: screensaver_clock_value
+          text: !lambda |-
+            static char time_buf[16];
+            auto now = id(sntp_time).now();
+            snprintf(time_buf, sizeof(time_buf), "%02d:%02d", now.hour, now.minute);
+            return time_buf;
+
+      - lvgl.label.update:
+          id: screensaver_clock_center_value
           text: !lambda |-
             static char time_buf[16];
             auto now = id(sntp_time).now();

--- a/src/widgets/home/home.yaml
+++ b/src/widgets/home/home.yaml
@@ -60,13 +60,13 @@ globals:
 number:
   - platform: template
     id: display_timeout_backlight
-    name: Backlight timeout
+    name: Screensaver timeout
     optimistic: true
-    unit_of_measurement: "m"
-    initial_value: 10
+    unit_of_measurement: "s"
+    initial_value: 60
     restore_value: true
     min_value: -1
-    max_value: 720
+    max_value: 600
     step: 1
     mode: box
 
@@ -157,6 +157,11 @@ sensor:
             text:
               format: "%.0f°"
               args: [id(weather_temperature_sensor).state]
+        - lvgl.label.update:
+            id: screensaver_outdoor_temp_value
+            text:
+              format: "%.0f°"
+              args: [id(weather_temperature_sensor).state]
 
   # Weather humidity sensor
   - platform: homeassistant
@@ -205,6 +210,30 @@ sensor:
             text:
               format: "%.1f°"
               args: [id(home_temperature_sensor).state]
+        - lvgl.label.update:
+            id: screensaver_indoor_temp_value
+            text:
+              format: "%.1f°"
+              args: [id(home_temperature_sensor).state]
+        - if:
+            condition:
+              lambda: 'return id(home_temperature_sensor).state >= 30.0;'
+            then:
+              - lvgl.label.update:
+                  id: screensaver_indoor_temp_value
+                  text_color: color_red
+            else:
+              - if:
+                  condition:
+                    lambda: 'return id(home_temperature_sensor).state >= 27.0;'
+                  then:
+                    - lvgl.label.update:
+                        id: screensaver_indoor_temp_value
+                        text_color: color_orange
+                  else:
+                    - lvgl.label.update:
+                        id: screensaver_indoor_temp_value
+                        text_color: color_misty_blue
 
   # Home humidity sensor
   - platform: homeassistant
@@ -217,6 +246,69 @@ sensor:
             text:
               format: "%.0f%%"
               args: [id(home_humidity_sensor).state]
+        - lvgl.label.update:
+            id: screensaver_humidity_value
+            text:
+              format: "%.0f%%"
+              args: [id(home_humidity_sensor).state]
+        - if:
+            condition:
+              lambda: 'return id(home_humidity_sensor).state >= 70.0 || id(home_humidity_sensor).state <= 20.0;'
+            then:
+              - lvgl.label.update:
+                  id: screensaver_humidity_value
+                  text_color: color_red
+            else:
+              - if:
+                  condition:
+                    lambda: 'return id(home_humidity_sensor).state >= 60.0 || id(home_humidity_sensor).state <= 30.0;'
+                  then:
+                    - lvgl.label.update:
+                        id: screensaver_humidity_value
+                        text_color: color_orange
+                  else:
+                    - lvgl.label.update:
+                        id: screensaver_humidity_value
+                        text_color: color_misty_blue
+
+  - platform: homeassistant
+    id: home_co2_sensor
+    entity_id: "${co2_entity}"
+    on_value:
+      then:
+        - lvgl.label.update:
+            id: screensaver_co2_value
+            text:
+              format: "%.0f"
+              args: [id(home_co2_sensor).state]
+        - if:
+            condition:
+              lambda: 'return id(home_co2_sensor).state >= 1200.0;'
+            then:
+              - lvgl.label.update:
+                  id: screensaver_co2_value
+                  text_color: color_red
+              - lvgl.label.update:
+                  id: screensaver_co2_unit
+                  text_color: color_red
+            else:
+              - if:
+                  condition:
+                    lambda: 'return id(home_co2_sensor).state >= 800.0;'
+                  then:
+                    - lvgl.label.update:
+                        id: screensaver_co2_value
+                        text_color: color_orange
+                    - lvgl.label.update:
+                        id: screensaver_co2_unit
+                        text_color: color_orange
+                  else:
+                    - lvgl.label.update:
+                        id: screensaver_co2_value
+                        text_color: color_misty_blue
+                    - lvgl.label.update:
+                        id: screensaver_co2_unit
+                        text_color: color_misty_blue
 
   # Chip temperature
   - platform: internal_temperature
@@ -359,17 +451,18 @@ text_sensor:
 lvgl:
 
   on_idle:
-    timeout: !lambda "return (id(display_timeout_backlight).state * 60 * 1000);"
+    timeout: !lambda |-
+      if (id(display_timeout_backlight).state < 0) {
+        return 2147483647;
+      }
+      return (uint32_t) (id(display_timeout_backlight).state * 1000);
     then:
       - if:
           condition:
             lambda: 'return id(display_timeout_backlight).state >= 0;'
           then:
             - logger.log: "LVGL is idle"
-            - light.turn_off: display_backlight
-            - lvgl.pause:
-          else:
-            - logger.log: "LVGL idle, but backlight is on"
+            - script.execute: show_screensaver
 
   pages:
     - id: home_page
@@ -815,23 +908,26 @@ lvgl:
                                 bg_opa: transp
                                 text_font: nunito_20
                                 text_color: color_misty_blue
-                              selected_index: !lambda return id(display_timeout);
+                              selected_index: !lambda |-
+                                if (id(display_timeout) < 0 || id(display_timeout) > 6) {
+                                  return 3;
+                                }
+                                return id(display_timeout);
                               options:
                                 - Never
+                                - 15 seconds
+                                - 30 seconds
                                 - 1 minute
+                                - 2 minutes
                                 - 5 minutes
                                 - 10 minutes
-                                - 30 minutes
-                                - 1 hour
-                                - 6 hours
-                                - 12 hours
                               visible_row_count: 1
                               on_value:
                                   then:
                                     - number.set:
                                         id: display_timeout_backlight
                                         value: !lambda |-
-                                          static const int backlight_time[] = {-1, 1, 5, 10, 30, 60, 360, 720};
+                                          static const int backlight_time[] = {-1, 15, 30, 60, 120, 300, 600};
                                           return backlight_time[x];
                                     - globals.set:
                                         id: display_timeout
@@ -1661,15 +1757,14 @@ script:
 
           uint16_t old_selection = lv_roller_get_selected(roller_obj);
 
-          std::string options = 
-            id(i18n_translations).translate("sleep_time.never") + "\n" +
-            id(i18n_translations).translate("sleep_time.minute1") + "\n" +
-            id(i18n_translations).translate("sleep_time.minute5") + "\n" +
-            id(i18n_translations).translate("sleep_time.minute10") + "\n" +
-            id(i18n_translations).translate("sleep_time.minute30") + "\n" +
-            id(i18n_translations).translate("sleep_time.hour1") + "\n" +
-            id(i18n_translations).translate("sleep_time.hour6") + "\n" +
-            id(i18n_translations).translate("sleep_time.hour12");
+          std::string options =
+            "Never\n"
+            "15 seconds\n"
+            "30 seconds\n"
+            "1 minute\n"
+            "2 minutes\n"
+            "5 minutes\n"
+            "10 minutes";
 
           lv_roller_set_options(roller_obj, options.c_str(), LV_ROLLER_MODE_NORMAL);
           lv_roller_set_selected(roller_obj, old_selection, LV_ANIM_OFF);
@@ -1763,6 +1858,28 @@ script:
             else show(id(weather_sunny_image));
           }
 
+          if (weather == "cloudy") lv_img_set_src(id(screensaver_weather_icon), id(cloudy_img));
+          else if (weather == "partlycloudy") {
+            if (is_night) lv_img_set_src(id(screensaver_weather_icon), id(partlycloudy_moon_img));
+            else lv_img_set_src(id(screensaver_weather_icon), id(partlycloudy_sun_img));
+          }
+          else if (weather == "sunny") lv_img_set_src(id(screensaver_weather_icon), id(sunny_img));
+          else if (weather == "clear-night") lv_img_set_src(id(screensaver_weather_icon), id(clear_night_img));
+          else if (weather == "rainy") lv_img_set_src(id(screensaver_weather_icon), id(rainy_img));
+          else if (weather == "lightning-rainy") lv_img_set_src(id(screensaver_weather_icon), id(lightning_rainy_img));
+          else if (weather == "lightning") lv_img_set_src(id(screensaver_weather_icon), id(lightning_img));
+          else if (weather == "pouring") lv_img_set_src(id(screensaver_weather_icon), id(pouring_img));
+          else if (weather == "snowy") lv_img_set_src(id(screensaver_weather_icon), id(snowy_img));
+          else if (weather == "snowy-rainy") lv_img_set_src(id(screensaver_weather_icon), id(snowy_rainy_img));
+          else if (weather == "fog") lv_img_set_src(id(screensaver_weather_icon), id(fog_img));
+          else if (weather == "hail") lv_img_set_src(id(screensaver_weather_icon), id(hail_img));
+          else if (weather == "windy") lv_img_set_src(id(screensaver_weather_icon), id(windy_img));
+          else if (weather == "windy-variant") lv_img_set_src(id(screensaver_weather_icon), id(windy_variant_img));
+          else {
+            if (is_night) lv_img_set_src(id(screensaver_weather_icon), id(clear_night_img));
+            else lv_img_set_src(id(screensaver_weather_icon), id(sunny_img));
+          }
+
   - id: log_widgets_status
     then:
       - lambda: |-
@@ -1806,6 +1923,14 @@ script:
           text: !lambda |-
             static char time_buf[16];
             auto now = id(sntp_time).now();            
+            snprintf(time_buf, sizeof(time_buf), "%02d:%02d", now.hour, now.minute);
+            return time_buf;
+
+      - lvgl.label.update:
+          id: screensaver_clock_value
+          text: !lambda |-
+            static char time_buf[16];
+            auto now = id(sntp_time).now();
             snprintf(time_buf, sizeof(time_buf), "%02d:%02d", now.hour, now.minute);
             return time_buf;
 

--- a/src/widgets/light/substitutions.yaml
+++ b/src/widgets/light/substitutions.yaml
@@ -1,7 +1,7 @@
 lights_amount: "4" # choise 1,2,3 or 4
 
-light_entity_1: "light.kitchen_chandelier_tmpl"
-light_entity_2: "light.dimmer_kitchen_tmpl"
+light_entity_1: "light.cbe_rgbcw_wi_fi_bluetooth_light"
+light_entity_2: "light.display01_backlight"
 light_entity_3: "light.lumi_v3_48df_light"
 light_entity_4: "light.office_rgbw_lights"
 

--- a/src/widgets/light/substitutions.yaml
+++ b/src/widgets/light/substitutions.yaml
@@ -1,7 +1,7 @@
 lights_amount: "4" # choise 1,2,3 or 4
 
-light_entity_1: "light.cbe_rgbcw_wi_fi_bluetooth_light"
-light_entity_2: "light.display01_backlight"
+light_entity_1: "light.kitchen_chandelier_tmpl"
+light_entity_2: "light.dimmer_kitchen_tmpl"
 light_entity_3: "light.lumi_v3_48df_light"
 light_entity_4: "light.office_rgbw_lights"
 

--- a/src/widgets/screensaver.yaml
+++ b/src/widgets/screensaver.yaml
@@ -111,6 +111,14 @@ lvgl:
                             text_font: nunito_64
                             text_color: color_misty_blue
                             text: '--.-°'
+                        - label:
+                            id: screensaver_outdoor_feels_like_value
+                            hidden: true
+                            align: BOTTOM_MID
+                            y: 0
+                            text_font: nunito_36
+                            text_color: color_steel_blue
+                            text: ''
 
             - obj:
                 id: screensaver_indoor_block

--- a/src/widgets/screensaver.yaml
+++ b/src/widgets/screensaver.yaml
@@ -77,18 +77,40 @@ lvgl:
                 radius: 0
                 pad_all: 0
                 widgets:
-                  - label:
-                      id: screensaver_outdoor_temp_value
-                      align: BOTTOM_MID
-                      y: -3
-                      text_font: nunito_64
-                      text_color: color_misty_blue
-                      text: '--.-°'
-                  - image:
-                      id: screensaver_weather_icon
+                  - obj:
+                      id: screensaver_outdoor_icon_area
+                      width: 240
+                      height: 110
                       align: TOP_MID
-                      y: 43
-                      src: cloudy_img
+                      bg_opa: transp
+                      border_opa: TRANSP
+                      border_width: 0
+                      shadow_opa: TRANSP
+                      pad_all: 0
+                      widgets:
+                        - image:
+                            id: screensaver_weather_icon
+                            align: CENTER
+                            src: cloudy_img
+
+                  - obj:
+                      id: screensaver_outdoor_temp_area
+                      width: 240
+                      height: 130
+                      align: BOTTOM_MID
+                      bg_opa: transp
+                      border_opa: TRANSP
+                      border_width: 0
+                      shadow_opa: TRANSP
+                      pad_all: 0
+                      widgets:
+                        - label:
+                            id: screensaver_outdoor_temp_value
+                            align: BOTTOM_MID
+                            y: -3
+                            text_font: nunito_64
+                            text_color: color_misty_blue
+                            text: '--.-°'
 
             - obj:
                 id: screensaver_indoor_block

--- a/src/widgets/screensaver.yaml
+++ b/src/widgets/screensaver.yaml
@@ -1,0 +1,154 @@
+globals:
+  - id: screensaver_active
+    type: bool
+    restore_value: false
+    initial_value: 'false'
+
+script:
+  - id: show_screensaver
+    then:
+      - if:
+          condition:
+            lambda: 'return !id(screensaver_active);'
+          then:
+            - globals.set:
+                id: screensaver_active
+                value: 'true'
+            - lvgl.widget.show: screensaver_overlay
+
+  - id: hide_screensaver
+    then:
+      - if:
+          condition:
+            lambda: 'return id(screensaver_active);'
+          then:
+            - globals.set:
+                id: screensaver_active
+                value: 'false'
+            - lvgl.widget.hide: screensaver_overlay
+
+lvgl:
+  top_layer:
+    widgets:
+      - obj:
+          id: screensaver_overlay
+          hidden: true
+          width: 100%
+          height: 100%
+          bg_color: color_slate_blue_gray
+          bg_opa: 100%
+          border_opa: TRANSP
+          border_width: 0
+          shadow_opa: TRANSP
+          pad_all: 0
+          widgets:
+            - obj:
+                id: screensaver_outdoor_block
+                x: 0
+                y: 0
+                width: 240
+                height: 240
+                align: TOP_LEFT
+                bg_color: color_steel_blue
+                bg_opa: 24%
+                border_opa: TRANSP
+                border_width: 0
+                shadow_opa: TRANSP
+                radius: 0
+                pad_all: 0
+                widgets:
+                  - label:
+                      id: screensaver_outdoor_temp_value
+                      align: BOTTOM_MID
+                      y: -3
+                      text_font: nunito_64
+                      text_color: color_misty_blue
+                      text: '--.-°'
+                  - image:
+                      id: screensaver_weather_icon
+                      align: TOP_MID
+                      y: 43
+                      src: cloudy_img
+
+            - obj:
+                id: screensaver_indoor_block
+                x: 240
+                y: 0
+                width: 240
+                height: 240
+                align: TOP_LEFT
+                bg_color: color_steel_blue
+                bg_opa: 24%
+                border_opa: TRANSP
+                border_width: 0
+                shadow_opa: TRANSP
+                radius: 0
+                pad_all: 0
+                widgets:
+                  - label:
+                      id: screensaver_clock_value
+                      align: TOP_RIGHT
+                      x: -12
+                      y: 10
+                      text_font: nunito_36
+                      text_color: color_misty_blue
+                      text: '--:--'
+                  - label:
+                      id: screensaver_indoor_temp_value
+                      align: CENTER
+                      y: 30
+                      text_font: nunito_64
+                      text_color: color_misty_blue
+                      text: '--.-°'
+
+            - obj:
+                id: screensaver_humidity_block
+                x: 0
+                y: 240
+                width: 240
+                height: 240
+                align: TOP_LEFT
+                bg_color: color_steel_blue
+                bg_opa: 24%
+                border_opa: TRANSP
+                border_width: 0
+                shadow_opa: TRANSP
+                radius: 0
+                pad_all: 0
+                widgets:
+                  - label:
+                      id: screensaver_humidity_value
+                      align: CENTER
+                      text_font: nunito_64
+                      text_color: color_misty_blue
+                      text: '--%'
+
+            - obj:
+                id: screensaver_co2_block
+                x: 240
+                y: 240
+                width: 240
+                height: 240
+                align: TOP_LEFT
+                bg_color: color_steel_blue
+                bg_opa: 24%
+                border_opa: TRANSP
+                border_width: 0
+                shadow_opa: TRANSP
+                radius: 0
+                pad_all: 0
+                widgets:
+                  - label:
+                      id: screensaver_co2_value
+                      align: CENTER
+                      y: -28
+                      text_font: nunito_64
+                      text_color: color_misty_blue
+                      text: '----'
+                  - label:
+                      id: screensaver_co2_unit
+                      align: CENTER
+                      y: 26
+                      text_font: nunito_30
+                      text_color: color_misty_blue
+                      text: 'ppm'

--- a/src/widgets/screensaver.yaml
+++ b/src/widgets/screensaver.yaml
@@ -27,6 +27,26 @@ script:
                 value: 'false'
             - lvgl.widget.hide: screensaver_overlay
 
+  - id: configure_screensaver_layout
+    then:
+      - if:
+          condition:
+            lambda: 'return "${has_co2}" == std::string("true");'
+          then:
+            - lvgl.widget.show: screensaver_indoor_temp_value
+            - lvgl.widget.show: screensaver_co2_value
+            - lvgl.widget.show: screensaver_co2_unit
+            - lvgl.widget.show: screensaver_clock_value
+            - lvgl.widget.hide: screensaver_clock_center_value
+            - lvgl.widget.hide: screensaver_temp_no_co2_value
+          else:
+            - lvgl.widget.hide: screensaver_indoor_temp_value
+            - lvgl.widget.hide: screensaver_co2_value
+            - lvgl.widget.hide: screensaver_co2_unit
+            - lvgl.widget.hide: screensaver_clock_value
+            - lvgl.widget.show: screensaver_clock_center_value
+            - lvgl.widget.show: screensaver_temp_no_co2_value
+
 lvgl:
   top_layer:
     widgets:
@@ -94,6 +114,13 @@ lvgl:
                       text_color: color_misty_blue
                       text: '--:--'
                   - label:
+                      id: screensaver_clock_center_value
+                      hidden: true
+                      align: CENTER
+                      text_font: nunito_72
+                      text_color: color_misty_blue
+                      text: '--:--'
+                  - label:
                       id: screensaver_indoor_temp_value
                       align: CENTER
                       y: 30
@@ -152,3 +179,10 @@ lvgl:
                       text_font: nunito_30
                       text_color: color_misty_blue
                       text: 'ppm'
+                  - label:
+                      id: screensaver_temp_no_co2_value
+                      hidden: true
+                      align: CENTER
+                      text_font: nunito_64
+                      text_color: color_misty_blue
+                      text: '--.-°'

--- a/src/widgets/screensaver.yaml
+++ b/src/widgets/screensaver.yaml
@@ -82,6 +82,7 @@ lvgl:
                       width: 240
                       height: 110
                       align: TOP_MID
+                      y: 10
                       bg_opa: transp
                       border_opa: TRANSP
                       border_width: 0

--- a/src/widgets/vacuum/substitutions.yaml
+++ b/src/widgets/vacuum/substitutions.yaml
@@ -1,3 +1,3 @@
-vacuum_entity: "vacuum.demo_vacuum_0_ground_floor"
+vacuum_entity: "vacuum.chistik"
 battery_level_entity: "sensor.vacuum_battery_level"
 cleaned_area_entity: "sensor.vacuum_cleaned_area"

--- a/src/widgets/vacuum/substitutions.yaml
+++ b/src/widgets/vacuum/substitutions.yaml
@@ -1,3 +1,3 @@
-vacuum_entity: "vacuum.chistik"
+vacuum_entity: "vacuum.demo_vacuum_0_ground_floor"
 battery_level_entity: "sensor.vacuum_battery_level"
 cleaned_area_entity: "sensor.vacuum_cleaned_area"


### PR DESCRIPTION
## Что сделано

Добавлен screensaver для дисплея с отдельной настройкой тайм-аута, не ломающей существующую логику сна экрана.

### Основное
- Добавлен полноэкранный screensaver с крупными показателями.
- Добавлена отдельная настройка `Screensaver` (время включения), независимая от `Sleep time`.
- Сохранена текущая логика `Sleep time`: она по-прежнему управляет отключением подсветки и паузой LVGL.
- Добавлен флаг `has_co2` в substitutions:
  - `has_co2: "true"` — 4 показателя (включая CO2),
  - `has_co2: "false"` — fallback-режим без CO2.

### Режим без CO2 (`has_co2: "false"`)
Скринсейвер перестраивается в 2x2:
- погода (иконка + уличная температура),
- часы (крупно, по центру),
- влажность,
- температура в помещении.

### Режим с CO2 (`has_co2: "true"`)
Остается 4-показательный вариант:
- погода,
- температура в помещении,
- влажность,
- CO2 (с `ppm` и цветовой индикацией порогов).


## Совместимость и дефолты

- Персональные entity_id удалены из PR.
- Дефолтные substitutions оставлены универсальными.
- Для CO2 используется заглушка:
  - `co2_entity: "sensor.carbon_dioxide"`(как ранее старом дизайне).

## Проверка

Локально проверено:
- `esphome config src/main.yaml` — OK
- `esphome compile src/main.yaml` — OK

Также проверено поведение:
- независимая работа `Sleep time` и `Screensaver`,
- корректное пробуждение по касанию,
- корректное отображение в режимах `has_co2: "true"` и `has_co2: "false"`.

## Скриншоты
<details>
<summary>Скринсейвер (has_co2=true)</summary>
<img width="1280" height="1280" alt="IMAGE 2026-04-29 01:50:50" src="https://github.com/user-attachments/assets/0b935fe4-cdbb-4e55-9096-8ee606025bf1" />
</details>


<details>
<summary>Скринсейвер (has_co2=false)</summary>
<img width="1280" height="1280" alt="IMAGE 2026-04-29 01:51:07" src="https://github.com/user-attachments/assets/b07fb993-159a-424d-99e0-1f7c0f1e3dc8" />
</details>


<details>
<summary>Настройки</summary>
<img width="1280" height="1280" alt="IMAGE 2026-04-29 01:51:11" src="https://github.com/user-attachments/assets/ca60c719-e925-40dd-a4e7-c291c146cd31" />
</details>
